### PR TITLE
Update

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -3,16 +3,15 @@ package main
 import (
 	"bytes"
 	"encoding/base64"
-	"net/http"
 	"time"
 
 	"go.uber.org/zap"
 )
 
-func setCache(key []byte, res *http.Response, b *bytes.Buffer) {
+func setCache(key []byte, s string, b *bytes.Buffer) {
 	logger.Info(string(b.Bytes()))
 	var e time.Duration = 3600
-	if s := res.Header.Get("Surrogate-Control"); s != "" {
+	if s != "" {
 		b := maxage.FindSubmatch([]byte(s))
 		if len(b) != 2 {
 			return

--- a/cache.go
+++ b/cache.go
@@ -11,7 +11,7 @@ import (
 
 func setCache(key []byte, res *http.Response, b *bytes.Buffer) {
 	logger.Info(string(b.Bytes()))
-	var e time.Duration = 0
+	var e time.Duration = 3600
 	if s := res.Header.Get("Surrogate-Control"); s != "" {
 		b := maxage.FindSubmatch([]byte(s))
 		if len(b) != 2 {

--- a/service.go
+++ b/service.go
@@ -73,9 +73,11 @@ func handleConn(c net.Conn, ip net.IP, h string, rq *http.Request, key []byte) {
 	}
 	b := new(bytes.Buffer)
 	wt := io.MultiWriter(c, b)
+	s := res.Header.Get("Surrogate-Control")
+	res.Header.Del("Surrogate-Control")
 	res.Write(wt)
 	if rq.Method == "GET" {
-		go setCache(key, res, b)
+		go setCache(key, s, b)
 	}
 
 }


### PR DESCRIPTION
- change: default cache duration
0s(= eternally)  to 3600s

- delete: Surrogate-Control Header
refer: https://docs.fastly.com/ja/guides/cache-control-tutorial